### PR TITLE
Drop scrapes with all zero counters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: build
 
 ENVVAR = GOOS=linux GOARCH=amd64
-TAG = v0.1.1
+TAG = v0.1.4
 APP_NAME = calico-accountant
 
 clean:

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -167,7 +167,7 @@ func parseFrom(stdout io.Reader, interfaceToWorkload map[string]*apiv3.WorkloadE
 			}
 			results = append(results, result)
 		case isAccept:
-			// When we find an accept line, we care about the packet count on the previous line
+			// When we find an accept line, we care about the target on the previous line
 			result, err := buildResult(workload, Accept, typ, packetCount, lastTarget)
 			if err != nil {
 				glog.Errorf("Error building result from line %s: %v", string(line), err)


### PR DESCRIPTION
This is to avoid an iptables bug where occasionally all counters are
zero for a single scrape. As it seems to affect literally every counter,
we can simply drop the scrape. Neat!