### PR TITLE
Allow a configurable minimum count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: build
 
 ENVVAR = GOOS=linux GOARCH=amd64
-TAG = v0.1.4
+TAG = v0.1.5
 APP_NAME = calico-accountant
 
 clean:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ providing `ETCD_ENDPOINTS`. The setup can be copied from the Calico kube-control
 * `NODENAME`: (string, default: hostname, to match calico node behaviour) Should be equal to `spec.nodeName`, ie the Kubernetes node name. 
 See the demo manifest for one way to provide this. If you don't provide this to calico node, you may not need to provide it here either.
 * `METRICS_SERVER_PORT`: (int, default: **9009**) Port for the service to host its metrics.
+* `MINIMUM_COUNTER`: (int, default **0**) Scrapes where all counts are below this value are dropped. This is to dodge iptables race conditions where counters briefly drop to near-zero and then return.
 
 ### Metrics 
 Metrics are implemented by Prometheus, which are hosted on the web server at `/metrics`. 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strconv"
 
 	"github.com/golang/glog"
 	"github.com/monzo/calico-accountant/metrics"
@@ -17,10 +18,20 @@ func main() {
 		port = "9009"
 	}
 
+	var minCounter int
+	minCounterStr, ok := os.LookupEnv("MINIMUM_COUNTER")
+	if ok {
+		var err error
+		minCounter, err = strconv.Atoi(minCounterStr)
+		if err != nil {
+			glog.Fatalf("Failed to parse minimum counter: %v", err)
+		}
+	}
+
 	cw, err := watch.New()
 	if err != nil {
 		glog.Fatalf("Error setting up calico watcher: %v", err)
 	}
 
-	metrics.Run(cw, port)
+	metrics.Run(cw, port, minCounter)
 }


### PR DESCRIPTION
Sometimes all counts are zero except one that is 1. It would be better
to drop a scrape if eg all are below 5.