### PR TITLE
Update demo and add additional resources required for demo to work

### DIFF
--- a/demo/daemonset.yaml
+++ b/demo/daemonset.yaml
@@ -1,15 +1,19 @@
 ---
-apiVersion: "extensions/v1beta1"
-kind: "DaemonSet"
+apiVersion: apps/v1
+kind: DaemonSet
 metadata:
-  name: "calico-accountant"
-  namespace: "kube-system"
+  name: calico-accountant
+  namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: calico-accountant
   template:
     metadata:
       labels:
-        app: "calico-accountant"
+        app: calico-accountant
     spec:
+      serviceAccountName: calico-accountant
       containers:
         - command:
            - "/calico-accountant"
@@ -21,12 +25,18 @@ spec:
               configMapKeyRef:
                 name: calico-config
                 key: etcd_endpoints
+          # On EKS/GKE with Calico using control plane etcd, 
+          # instead of ETCD_ENDPOINTS, use:
+#         - name: DATASTORE_TYPE
+#           value: "kubernetes"
           - name: NODE_NAME
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: "monzo/calico-accountant:v0.1.1"
-          name: "calico-accountant"
+          - name: METRICS_SERVER_PORT
+            value: "9009"
+          image: monzo/calico-accountant:v0.1.1 
+          name: calico-accountant
           securityContext:
             privileged: true
       hostNetwork: true

--- a/demo/rbac.yaml
+++ b/demo/rbac.yaml
@@ -23,6 +23,7 @@ rules:
     - ippools
     - kubecontrollersconfigurations
     - networkpolicies
+---
 apiVersion: v1
     - networksets
     - hostendpoints

--- a/demo/rbac.yaml
+++ b/demo/rbac.yaml
@@ -23,8 +23,6 @@ rules:
     - ippools
     - kubecontrollersconfigurations
     - networkpolicies
----
-apiVersion: v1
     - networksets
     - hostendpoints
     - ipamblocks

--- a/demo/rbac.yaml
+++ b/demo/rbac.yaml
@@ -1,0 +1,56 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: calico-accountant
+rules:
+- apiGroups: [""]
+  resources: ["pods", "services", "endpoints"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets", "statefulsets", "replicasets", "deployments"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "watch", "list", "create", "patch", "update"]
+- apiGroups: ["crd.projectcalico.org"]
+  resources:
+    - bgppeers
+    - bgpconfigurations
+    - clusterinformations
+    - felixconfigurations
+    - globalnetworkpolicies
+    - globalnetworksets
+    - ippools
+    - kubecontrollersconfigurations
+    - networkpolicies
+apiVersion: v1
+    - networksets
+    - hostendpoints
+    - ipamblocks
+    - blockaffinities
+    - ipamhandles
+    - ipamconfigs
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups: ["networking.k8s.io"]
+  resources:
+    - networkpolicies
+  verbs:
+    - get
+    - list
+    - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-accountant
+subjects:
+- kind: ServiceAccount
+  name: calico-accountant
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-accountant

--- a/demo/serviceaccount.yaml
+++ b/demo/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-accountant
+  namespace: kube-system


### PR DESCRIPTION
* `extensions/v1beta1` is deprecated for all supported Kubernetes version now
* Add RBAC and ServiceAccount resources required for the demo
* Add commented out env alternative if Calico using Kubernetes etcd (EKS, GKE).